### PR TITLE
Add logging of encrypted buffer per ELG-252

### DIFF
--- a/libel/libel.c
+++ b/libel/libel.c
@@ -705,6 +705,7 @@ Sky_finalize_t sky_finalize_request(Sky_ctx_t *ctx, Sky_errno_t *sky_errno, void
         *sky_errno = SKY_ERROR_NONE;
 
         LOGFMT(ctx, SKY_LOG_LEVEL_DEBUG, "Request buffer of %d bytes prepared", rc)
+        LOG_BUFFER(ctx, SKY_LOG_LEVEL_DEBUG, request_buf, rc)
         return SKY_FINALIZE_REQUEST;
     } else {
         *sky_errno = SKY_ERROR_ENCODE_ERROR;

--- a/libel/utilities.h
+++ b/libel/utilities.h
@@ -27,8 +27,10 @@
 
 #if SKY_DEBUG
 #define LOGFMT(...) logfmt(__FILE__, __FUNCTION__, __VA_ARGS__);
+#define LOG_BUFFER(c, l, b, s) log_buffer(__FILE__, __FUNCTION__, c, l, b, s);
 #else
 #define LOGFMT(...)
+#define LOG_BUFFER(c, l, b, s)
 #endif
 Sky_status_t sky_return(Sky_errno_t *sky_errno, Sky_errno_t code);
 int validate_workspace(Sky_ctx_t *ctx);
@@ -42,6 +44,8 @@ Sky_status_t add_beacon(Sky_ctx_t *ctx, Sky_errno_t *sky_errno, Beacon_t *b, boo
 const char *sky_basename(const char *path);
 int logfmt(
     const char *file, const char *function, Sky_ctx_t *ctx, Sky_log_level_t level, char *fmt, ...);
+int log_buffer(const char *file, const char *function, Sky_ctx_t *ctx, Sky_log_level_t level,
+    void *buffer, uint32_t bufsize);
 #endif
 void dump_workspace(Sky_ctx_t *ctx);
 void dump_cache(Sky_ctx_t *ctx);


### PR DESCRIPTION
I implemented a generic LOG_BUFFER routine which pretty prints for human consumption, however, since the primary (and currently sole) reason for this routine is to dump the encrypted bytes, it is (as Simon pointed out) more important that the dump is machine consumable.

Please take a look. I feel adding a flag to turn on pretty print might be a good move, and when it is not-pretty, dump un-formatted hex values up to the SKY_LOG_LENGTH.