### PR TITLE
Elg 267

### DIFF
--- a/libel/beacons.c
+++ b/libel/beacons.c
@@ -27,7 +27,6 @@
 #include <time.h>
 #include <math.h>
 #include <stdio.h>
-#include "../.submodules/tiny-AES128-C/aes.h"
 #define SKY_LIBEL 1
 #include "libel.h"
 

--- a/libel/libel.c
+++ b/libel/libel.c
@@ -108,7 +108,7 @@ Sky_status_t copy_state(Sky_errno_t *sky_errno, Sky_cache_t *c, Sky_cache_t *sky
  *  be truncated to 16 if larger, without causing an error.
  */
 Sky_status_t sky_open(Sky_errno_t *sky_errno, uint8_t *device_id, uint32_t id_len,
-    uint32_t partner_id, uint8_t aes_key[16], void *state_buf, Sky_log_level_t min_level,
+    uint32_t partner_id, uint8_t aes_key[AES_KEYLEN], void *state_buf, Sky_log_level_t min_level,
     Sky_loggerfn_t logf, Sky_randfn_t rand_bytes, Sky_timefn_t gettime)
 {
 #if SKY_DEBUG
@@ -119,7 +119,7 @@ Sky_status_t sky_open(Sky_errno_t *sky_errno, uint8_t *device_id, uint32_t id_le
     int j = 0;
 
     /* Only consider up to 16 bytes. Ignore any extra */
-    id_len = (id_len > MAX_DEVICE_ID) ? 16 : id_len;
+    id_len = (id_len > MAX_DEVICE_ID) ? MAX_DEVICE_ID : id_len;
 
     if (sky_state != NULL && !validate_cache(sky_state, logf)) {
         if (logf != NULL && SKY_LOG_LEVEL_WARNING <= min_level)

--- a/libel/libel.h
+++ b/libel/libel.h
@@ -132,14 +132,14 @@ typedef int (*Sky_randfn_t)(uint8_t *rand_buf, uint32_t bufsize);
  */
 typedef time_t (*Sky_timefn_t)(time_t *t);
 
-#ifndef SKY_LIBEL
-typedef void Sky_ctx_t;
-#define MAC_SIZE 6
-#else
+#ifdef SKY_LIBEL
 #include "config.h"
 #include "beacons.h"
 #include "workspace.h"
 #include "utilities.h"
+#else
+typedef void Sky_ctx_t;
+#define MAC_SIZE 6
 #endif
 
 Sky_status_t sky_open(Sky_errno_t *sky_errno, uint8_t *device_id, uint32_t id_len,

--- a/libel/libel.h
+++ b/libel/libel.h
@@ -22,15 +22,14 @@
  * IN THE SOFTWARE.
  *
  */
+#ifndef SKY_LIBEL_H
+#define SKY_LIBEL_H
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
 #include <time.h>
 
-#ifndef SKY_LIBEL_H
-#define SKY_LIBEL_H
-
-#define MAC_SIZE 6
 #define AES_SIZE 16
 
 #define MAX_DEVICE_ID 16
@@ -132,8 +131,12 @@ typedef int (*Sky_randfn_t)(uint8_t *rand_buf, uint32_t bufsize);
 typedef time_t (*Sky_timefn_t)(time_t *t);
 
 #ifndef SKY_LIBEL
+#include "aes.h"
+#include "crc32.h"
 typedef void Sky_ctx_t;
+#define MAC_SIZE 6
 #else
+#include "aes.h"
 #include "config.h"
 #include "beacons.h"
 #include "crc32.h"
@@ -142,7 +145,7 @@ typedef void Sky_ctx_t;
 #endif
 
 Sky_status_t sky_open(Sky_errno_t *sky_errno, uint8_t *device_id, uint32_t id_len,
-    uint32_t partner_id, uint8_t aes_key[16], void *state_buf, Sky_log_level_t min_level,
+    uint32_t partner_id, uint8_t aes_key[AES_KEYLEN], void *state_buf, Sky_log_level_t min_level,
     Sky_loggerfn_t logf, Sky_randfn_t rand_bytes, Sky_timefn_t gettime);
 
 int32_t sky_sizeof_state(void *sky_state);
@@ -151,7 +154,7 @@ int32_t sky_sizeof_workspace(void);
 
 Sky_ctx_t *sky_new_request(void *workspace_buf, uint32_t bufsize, Sky_errno_t *sky_errno);
 
-Sky_status_t sky_add_ap_beacon(Sky_ctx_t *ctx, Sky_errno_t *sky_errno, uint8_t mac[6],
+Sky_status_t sky_add_ap_beacon(Sky_ctx_t *ctx, Sky_errno_t *sky_errno, uint8_t mac[MAC_SIZE],
     time_t timestamp, int16_t rssi, int32_t freq, bool is_connected);
 
 Sky_status_t sky_add_cell_lte_beacon(Sky_ctx_t *ctx, Sky_errno_t *sky_errno, uint16_t tac,

--- a/libel/libel.h
+++ b/libel/libel.h
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <time.h>
+#include "aes.h"
 
 #define AES_SIZE 16
 
@@ -131,12 +132,10 @@ typedef int (*Sky_randfn_t)(uint8_t *rand_buf, uint32_t bufsize);
 typedef time_t (*Sky_timefn_t)(time_t *t);
 
 #ifndef SKY_LIBEL
-#include "aes.h"
 #include "crc32.h"
 typedef void Sky_ctx_t;
 #define MAC_SIZE 6
 #else
-#include "aes.h"
 #include "config.h"
 #include "beacons.h"
 #include "crc32.h"

--- a/libel/libel.h
+++ b/libel/libel.h
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <time.h>
 #include "aes.h"
+#include "crc32.h"
 
 #define AES_SIZE 16
 
@@ -132,13 +133,11 @@ typedef int (*Sky_randfn_t)(uint8_t *rand_buf, uint32_t bufsize);
 typedef time_t (*Sky_timefn_t)(time_t *t);
 
 #ifndef SKY_LIBEL
-#include "crc32.h"
 typedef void Sky_ctx_t;
 #define MAC_SIZE 6
 #else
 #include "config.h"
 #include "beacons.h"
-#include "crc32.h"
 #include "workspace.h"
 #include "utilities.h"
 #endif

--- a/libel/unit_test.c
+++ b/libel/unit_test.c
@@ -29,7 +29,6 @@
 #include <inttypes.h>
 #include <time.h>
 #include <math.h>
-#include "../.submodules/tiny-AES128-C/aes.h"
 #define SKY_LIBEL 1
 #include "libel.h"
 #include "crc32.h"

--- a/libel/utilities.c
+++ b/libel/utilities.c
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
-#include "../.submodules/tiny-AES128-C/aes.h"
 #define SKY_LIBEL 1
 #include "libel.h"
 

--- a/libel/workspace.h
+++ b/libel/workspace.h
@@ -58,9 +58,9 @@ typedef struct sky_config_pad {
 typedef struct sky_cache {
     Sky_header_t header; /* magic, size, timestamp, crc32 */
     uint32_t sky_id_len; /* device ID len */
-    uint8_t sky_device_id[MAC_SIZE]; /* device ID */
+    uint8_t sky_device_id[MAX_DEVICE_ID]; /* device ID */
     uint32_t sky_partner_id; /* partner ID */
-    uint8_t sky_aes_key[16]; /* aes key */
+    uint8_t sky_aes_key[AES_KEYLEN]; /* aes key */
     int len; /* number of cache lines */
     Sky_cacheline_t cacheline[CACHE_SIZE]; /* beacons */
     int newest;

--- a/sample_client/Makefile
+++ b/sample_client/Makefile
@@ -1,6 +1,8 @@
 CFLAGS = -Wall -Werror -Os -std=c99
 LIB_DIR = ../bin
-INCLUDES = -I. -I../libel
+AES_DIR = ../.submodules/tiny-AES128-C
+
+INCLUDES = -I. -I../libel -I${AES_DIR}
 CLIENT_NAME = sample_client
 
 CLIENT_SRCS = sample_client.c send.c config.c

--- a/sample_client/sample_client.c
+++ b/sample_client/sample_client.c
@@ -28,9 +28,7 @@
 #include <inttypes.h>
 #include <time.h>
 #include <math.h>
-#include "../.submodules/tiny-AES128-C/aes.h"
 
-#define SKY_LIBEL 1
 #include "libel.h"
 
 #include "send.h"


### PR DESCRIPTION
Addressed the device_id length issue and found a number of other issues related to AES_KEYLEN and include files. Release notes should now mention that the client code (and sample_client.c) no longer should set SKY_LIBEL which is reserved  for the internal libel files.