### PR TITLE
[ELG-269] Abort makefile with message if sub-modules are not provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,15 @@ LIBELG_OBJS = $(addprefix ${BUILD_DIR}/, $(notdir $(LIBELG_ALL:.c=.o)))
 
 all: .submodules/nanopb/README.md .submodules/tiny-AES128-C/README.md .submodules/embedded-protocol/README.md lib unit_test
 
-.submodules/nanopb/README.md:
+.submodules/nanopb/.git:
 	@echo "submodule nanopb must be provided! Did you download embedded-client-X.X.X.tgz? Exiting..."
 	exit 1
 
-.submodules/tiny-AES128-C/README.md:
+.submodules/tiny-AES128-C/.git:
 	@echo "submodule tiny-AES128-C must be provided! Did you download embedded-client-X.X.X.tgz? Exiting..."
 	exit 1
 
-.submodules/embedded-protocol/README.md:
+.submodules/embedded-protocol/.git:
 	@echo "submodule embedded-protocol must be provided! Did you download embedded-client-X.X.X.tgz? Exiting..."
 	exit 1
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ TINYAES_SRCS = ${AES_DIR}/aes.c
 LIBELG_ALL = ${LIBELG_SRCS} ${PROTO_SRCS} ${TINYAES_SRCS} 
 LIBELG_OBJS = $(addprefix ${BUILD_DIR}/, $(notdir $(LIBELG_ALL:.c=.o)))
 
-all: .submodules/nanopb/README.md .submodules/tiny-AES128-C/README.md .submodules/embedded-protocol/README.md lib unit_test
+all: .submodules/nanopb/.git .submodules/tiny-AES128-C/.git .submodules/embedded-protocol/.git lib unit_test
 
 .submodules/nanopb/.git:
 	@echo "submodule nanopb must be provided! Did you download embedded-client-X.X.X.tgz? Exiting..."

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,19 @@ TINYAES_SRCS = ${AES_DIR}/aes.c
 LIBELG_ALL = ${LIBELG_SRCS} ${PROTO_SRCS} ${TINYAES_SRCS} 
 LIBELG_OBJS = $(addprefix ${BUILD_DIR}/, $(notdir $(LIBELG_ALL:.c=.o)))
 
-.PHONY: unit_test proto lib
+all: .submodules/nanopb/README.md .submodules/tiny-AES128-C/README.md .submodules/embedded-protocol/README.md lib unit_test
+
+.submodules/nanopb/README.md:
+	@echo "submodule nanopb must be provided! Did you download embedded-client-X.X.X.tgz? Exiting..."
+	exit 1
+
+.submodules/tiny-AES128-C/README.md:
+	@echo "submodule tiny-AES128-C must be provided! Did you download embedded-client-X.X.X.tgz? Exiting..."
+	exit 1
+
+.submodules/embedded-protocol/README.md:
+	@echo "submodule embedded-protocol must be provided! Did you download embedded-client-X.X.X.tgz? Exiting..."
+	exit 1
 
 lib: ${BIN_DIR} ${BUILD_DIR} ${BIN_DIR}/libel.a
 


### PR DESCRIPTION
If the git files is not present in a sub-module, a helpful message is reported and the build aborts immediately.
```
$ make
which: no armcc in (/home/gcleary//.pyenv/shims:/home/gcleary//.pyenv/bin:.:/home/gcleary//bin:/usr/local/bin:/opt/rh/llvm-toolset-7/root/usr/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/gcleary//.local/bin:/home/gcleary//bin)
submodule embedded-protocol must be provided! Did you download embedded-client-xxx.tgz? Exiting...
exit 1
make: *** [.submodules/embedded-protocol/README.md] Error 1
```